### PR TITLE
Update Mal_Loader_Sload_Sep-2020-1.yar

### DIFF
--- a/2020-09-14/SLoad/Mal_Loader_Sload_Sep-2020-1.yar
+++ b/2020-09-14/SLoad/Mal_Loader_Sload_Sep-2020-1.yar
@@ -1,4 +1,4 @@
-rule Mal_Loader_Sload_Sep-2020-1 {
+rule Mal_Loader_Sload_Sep_2020_1 {
    meta:
       description = "Detect SLoad loader"
       author = "Arkbird_SOLG"
@@ -29,7 +29,7 @@ rule Mal_Loader_Sload_Sep-2020-1 {
       $s7 = "New RegExp" fullword ascii
       $s8 = ".[run]" fullword ascii
       $s9 = "fso.FolderExists(" fullword ascii
-      $s10 = { [4-5] 3D [4-5] 66 }
+      $s10 = { 3D [4-5] 66 }
    condition:
        filesize > 2KB and 7 of them
 }


### PR DESCRIPTION
Line 1: rule Mal_Loader_Sload_Sep-2020-1 

Above causes syntax error. I've corrected it to below instead:

Line 1: rule Mal_Loader_Sload_Sep_2020_1

---

Line 32: s10 = { [4-5] 3D [4-5] 66 }

Above causes syntax error as there should be bytes before and after a jump. In the case above, there is no bytes before the first jump. I've corrected it to below instead:

Line 32: s10 = { 3D [4-5] 66 }

---

All the changes are verified with https://yaravalidator.manalyzer.org/
